### PR TITLE
fix the released token value

### DIFF
--- a/semaphore/unlock.go
+++ b/semaphore/unlock.go
@@ -37,7 +37,7 @@ func (s *semaphore) unlock(resources ...string) (err error) {
 
 		var resourcesAsInterface []interface{}
 
-		for resource := range resources {
+		for _, resource := range resources {
 			resourcesAsInterface = append(resourcesAsInterface, resource)
 		}
 


### PR DESCRIPTION
The released token value is always `0` currently,  here is the cmd of redis:

```sh
1585289102.673865 [0 :37759] "hdel" "semaphore:rmt:host:10.103.113.83:locked" "e9e8feb2-1dee-48a6-889c-3a6fa328fc33:1585289102607926063"
1585289102.673882 [0 :37759] "rpush" "semaphore:rmt:host:10.103.113.83:available" "0"
1585289102.673910 [0 :37759] "pexpire" "semaphore:rmt:host:10.103.113.83" "7200000"

...

1585289103.712386 [0 :37767] "hdel" "semaphore:rmt:host:10.103.112.41:locked" "6b04bd69-641a-453e-b362-1cee2093cbe3:1585289103610856635"
1585289103.712402 [0 :37767] "rpush" "semaphore:rmt:host:10.103.112.41:available" "0"
1585289103.712413 [0 :37767] "pexpire" "semaphore:rmt:host:10.103.112.41" "7200000"
```
